### PR TITLE
draft for Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 auth
 previous
 admins
+config
+_*
+.*

--- a/bot.py
+++ b/bot.py
@@ -41,9 +41,13 @@ class CsBot(discord.Client):
         self.broadcast_channel = None
         self.message_handlers = []
         self.reaction_handlers = []
+        registrationhandler = RegistrationHandler(["!register","!cancel","!end"],"Register new match","Not implemented",False, Permissions.admin)
+        self.message_handlers.append(registrationhandler)
+        self.reaction_handlers.append(registrationhandler)
+
         self.message_handlers.append(GenericMessageHandler(["!signup"], "Sign up for season", "Signup not implemented",True,Permissions.unrestricted))
         self.message_handlers.append(GenericMessageHandler(["!optout"], "Opt out of the rest of the season", "Optout not implemented",True,Permissions.member))
-        self.message_handlers.append(RegistrationHandler(["!register","!cancel","!end"],"Register new match","Not implemented",False, Permissions.admin))
+        # self.message_handlers.append(RegistrationHandler(["!register","!cancel","!end"],"Register new match","Not implemented",False, Permissions.admin))
         # self.message_handlers.append(GenericMessageHandler("!cancel", "Cancel match registration", "Not implemented",False,Permissions.admin))
         # self.message_handlers.append(GenericMessageHandler("!end", "End registration period for next match", "Not implemented",False,Permissions.admin))
         self.message_handlers.append(GenericMessageHandler(["!maps"], "Start registration of map preferences", "Maps not implemented",True,Permissions.member))
@@ -80,28 +84,28 @@ class CsBot(discord.Client):
                     return r
 
     async def on_raw_reaction_add(self, reaction):
-        permissions = await self.get_permissions(reaction.member)
+        permissions = await self.get_permissions(reaction.user_id)
         for handler in self.reaction_handlers:
             await handler.method(reaction, permissions)
 
     async def on_raw_reaction_remove(self, reaction):
-        permissions = await self.get_permissions(reaction.member)
+        permissions = await self.get_permissions(reaction.user_id)
         for handler in self.reaction_handlers:
             await handler.method(reaction, permissions)
 
     async def on_message(self, message):
         if message.author == self.user:
             return
-        permissions = await self.get_permissions(message.author)
+        permissions = await self.get_permissions(message.author.id)
         for handler in self.message_handlers:
             await handler.method(message, permissions)
 
-    async def get_permissions(self, user):
-        if user.id in self.config.super_users_id:
-            return 3
-        if user in self.config.role.members:
-            return 2
-        return 1
+    async def get_permissions(self, userID):
+        if userID in self.config.super_users_id:
+            return Permissions.admin
+        if userID in self.config.role.members:
+            return Permissions.member
+        return Permissions.standard
 
 
 if __name__ == "__main__":

--- a/bot.py
+++ b/bot.py
@@ -41,27 +41,27 @@ class CsBot(discord.Client):
         self.broadcast_channel = None
         self.message_handlers = []
         self.reaction_handlers = []
-        registrationhandler = RegistrationHandler(["!register","!cancel","!end"],"Register new match","Not implemented",False, Permissions.admin)
+        registrationhandler = RegistrationHandler("Register new match","Not implemented",False)
         self.message_handlers.append(registrationhandler)
         self.reaction_handlers.append(registrationhandler)
 
-        self.message_handlers.append(GenericMessageHandler(["!signup"], "Sign up for season", "Signup not implemented",True,Permissions.unrestricted))
-        self.message_handlers.append(GenericMessageHandler(["!optout"], "Opt out of the rest of the season", "Optout not implemented",True,Permissions.member))
+        self.message_handlers.append(GenericMessageHandler("Sign up for season", "Signup not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("Opt out of the rest of the season", "Optout not implemented",True))
         # self.message_handlers.append(RegistrationHandler(["!register","!cancel","!end"],"Register new match","Not implemented",False, Permissions.admin))
         # self.message_handlers.append(GenericMessageHandler("!cancel", "Cancel match registration", "Not implemented",False,Permissions.admin))
         # self.message_handlers.append(GenericMessageHandler("!end", "End registration period for next match", "Not implemented",False,Permissions.admin))
-        self.message_handlers.append(GenericMessageHandler(["!maps"], "Start registration of map preferences", "Maps not implemented",True,Permissions.member))
-        self.message_handlers.append(GenericMessageHandler(["!next"], "Show next match", "Next not implemented",False,Permissions.unrestricted))
-        self.message_handlers.append(GenericMessageHandler(["!upcoming"], "???", "Not implemented",True,Permissions.unrestricted))
-        self.message_handlers.append(GenericMessageHandler(["!commands"], "List of available commands", "Commands not implemented",False,Permissions.standard))
-        self.message_handlers.append(GenericMessageHandler(["!purge"], "???", "Not implemented",True,Permissions.admin))
-        self.message_handlers.append(GenericMessageHandler(["!easterEgg"], "???", "Not implemented",True,Permissions.admin))
-        self.message_handlers.append(GenericMessageHandler(["!dank"], "???", "Not implemented",True,Permissions.standard))
-        self.message_handlers.append(GenericMessageHandler(["!setAdmin"], "???", "Not implemented",True,Permissions.admin))
-        self.message_handlers.append(GenericMessageHandler(["!removeAdmin"], "???", "Not implemented",True,Permissions.admin))
-        self.message_handlers.append(GenericMessageHandler(["!admins"], "???", "Not implemented",True,Permissions.standard))
-        self.message_handlers.append(GenericMessageHandler(["!shutdown"], "???", "Not implemented",True,Permissions.admin))
-        self.message_handlers.append(GenericMessageHandler(["!reset"], "???", "Not implemented",True,Permissions.admin))
+        self.message_handlers.append(GenericMessageHandler("Start registration of map preferences", "Maps not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("Show next match", "Next not implemented",False))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("List of available commands", "Commands not implemented",False))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
+        self.message_handlers.append(GenericMessageHandler("???", "Not implemented",True))
 
     async def on_ready(self):
         self.config.role = await self.get_role()
@@ -84,28 +84,27 @@ class CsBot(discord.Client):
                     return r
 
     async def on_raw_reaction_add(self, reaction):
-        permissions = await self.get_permissions(reaction.user_id)
+        permissions = await self.get_permissions(reaction.member)
         for handler in self.reaction_handlers:
-            await handler.method(reaction, permissions)
+            await handler.dispatch(reaction, permissions)
 
     async def on_raw_reaction_remove(self, reaction):
-        permissions = await self.get_permissions(reaction.user_id)
+        permissions = await self.get_permissions(reaction.member)
         for handler in self.reaction_handlers:
-            await handler.method(reaction, permissions)
+            await handler.dispatch(reaction, permissions)
 
     async def on_message(self, message):
         if message.author == self.user:
             return
-        permissions = await self.get_permissions(message.author.id)
+        permissions = await self.get_permissions(message.author)
         for handler in self.message_handlers:
-            await handler.method(message, permissions)
+            await handler.dispatch(message, permissions)
 
-    async def get_permissions(self, userID):
-        if userID in self.config.super_users_id:
+    async def get_permissions(self, member):
+        if self.broadcast_channel.permissions_for(member).manage_roles:
             return Permissions.admin
-        if userID in self.config.role.members:
-            return Permissions.member
-        return Permissions.standard
+        else:
+            return Permissions.unrestricted
 
 
 if __name__ == "__main__":

--- a/config_example.json
+++ b/config_example.json
@@ -1,5 +1,6 @@
 {
     "ownerID": "<int> ID for the owner of the bot",
+    "server ID": "<int> ID for the server",
     "admin IDs": "[int,int,int...] IDs for the administrators for the bot",
     "team role ID": "<int> ID of member-role for playing members",
     "broadcast channel":"<string> Name of channel for bot broadcasting"

--- a/config_example.json
+++ b/config_example.json
@@ -1,0 +1,6 @@
+{
+    "ownerID": "<int> ID for the owner of the bot",
+    "admin IDs": "[int,int,int...] IDs for the administrators for the bot",
+    "team role ID": "<int> ID of member-role for playing members",
+    "broadcast channel":"<string> Name of channel for bot broadcasting"
+}

--- a/configuration.py
+++ b/configuration.py
@@ -1,16 +1,78 @@
+import json
+
+
 class Configuration():
-    def __init__(self,owner=None, admin=[], server=None, role=None):
+    def __init__(self,config_file="config"):
+        self.config_file = config_file
         self.owner = None
         self.super_users_id = None
         self.server = None
         self.team_role = None
-        self.parseParams(owner,admin,server,role)
+        self.broadcast_channel = None
         self.guild = ""
         self.role = ""
+        self.team_role = None
+        self.setup()
 
-    def parseParams(self,owner,admin,server,role):
-        self.owner = owner
-        self.super_users_id = admin
-        self.super_users_id.append(self.owner)
-        self.server = server
-        self.team_role = role
+
+    def _setupCfgTerminal(self):
+        try:
+            owner = int(input("OwnerID: "))
+            admins = input("Admin IDs, space separated: ")
+            if admins:
+                admins = [int(admin) for admin in admins.split('')]
+            team_role = None
+            while not team_role:
+                team_role = int(input("Team role ID: "))
+            broadcast_channel = input("Name of broadcast channel: ")
+            cfg = {
+                "ownerID":owner,
+                "admin IDs":admins,
+                "team role ID":team_role,
+                "broadcast channel":broadcast_channel
+            }
+            with open(self.config_file,"w") as f:
+                json.dump(cfg,f)
+        except Exception as e:
+            print(e)
+            print(type(e))
+            exit()
+
+    def setup(self):
+        config = {}
+        loaded = False
+        while(not loaded):
+            try:
+                with open(self.config_file) as f:
+                    config = json.load(f)
+                    self.owner = config["ownerID"]
+                    self.super_users_id = [id for id in config["admin IDs"]]
+                    if self.owner not in self.super_users_id:
+                        self.super_users_id.append(self.owner)
+                    self.team_role = config["team role ID"]
+                    self.broadcast_channel = config["broadcast channel"]
+                    loaded = True
+            except FileNotFoundError as ferr:
+                print(ferr)
+                if input("Would you like to setup the config from the terminal? y/n ") == 'y':
+                    self._setupCfgTerminal()
+                else:
+                    exit(f"Please setup your config: {self.config_file}")
+            except json.decoder.JSONDecodeError as derr:
+                print(derr)
+                if input("Would you like to setup the config from the terminal? y/n ") == 'y':
+                    self._setupCfgTerminal()
+                else:
+                    exit(f"Please setup your config: {self.config_file}")
+            except KeyError as kerr:
+                print(kerr)
+                if input("Would you like to setup the config from the terminal? y/n ") == 'y':
+                    self._setupCfgTerminal()
+                else:
+                    exit(f"Please setup your config: {self.config_file}")
+            except Exception as e:
+                print(e)
+                print(type(e))
+                exit()
+        
+

--- a/configuration.py
+++ b/configuration.py
@@ -5,7 +5,6 @@ class Configuration():
     def __init__(self,config_file="config"):
         self.config_file = config_file
         self.owner = None
-        self.super_users_id = None
         self.server = None
         self.team_role = None
         self.broadcast_channel = None
@@ -18,18 +17,16 @@ class Configuration():
     def _setupCfgTerminal(self):
         try:
             owner = int(input("OwnerID: "))
-            admins = input("Admin IDs, space separated: ")
-            if admins:
-                admins = [int(admin) for admin in admins.split('')]
             team_role = None
             while not team_role:
                 team_role = int(input("Team role ID: "))
             broadcast_channel = input("Name of broadcast channel: ")
+            server_id = int(input("Server ID: "))
             cfg = {
                 "ownerID":owner,
-                "admin IDs":admins,
                 "team role ID":team_role,
-                "broadcast channel":broadcast_channel
+                "broadcast channel":broadcast_channel,
+                "server ID":server_id
             }
             with open(self.config_file,"w") as f:
                 json.dump(cfg,f)
@@ -46,11 +43,9 @@ class Configuration():
                 with open(self.config_file) as f:
                     config = json.load(f)
                     self.owner = config["ownerID"]
-                    self.super_users_id = [id for id in config["admin IDs"]]
-                    if self.owner not in self.super_users_id:
-                        self.super_users_id.append(self.owner)
                     self.team_role = config["team role ID"]
                     self.broadcast_channel = config["broadcast channel"]
+                    self.server = config["server ID"]
                     loaded = True
             except FileNotFoundError as ferr:
                 print(ferr)

--- a/constants.py
+++ b/constants.py
@@ -1,1 +1,27 @@
 maps = ["Dust 2", "Mirage", "Vertigo", "Nuke", "Ancient", "Inferno", "Overpass"]
+ranks = {
+0:"Silver 1",
+1:"Silver 2",
+2:"Silver 3",
+3:"Silver IV",
+4:"Silver Elite",
+5:"Silver Elite Master",
+6:"Gold Nova 1",
+7:"Gold Nova 2",
+8:"Gold Nova 3",
+9:"Gold Nova Master",
+10:"Master Guardian 1",
+11:"Master Guardian 2",
+12:"Master Guardian Elite",
+13:"DMG",
+14:"Legendary Eagle",
+15:"Legendary Eagle Master",
+16:"Supreme Master First Class",
+17:"Global Elite"
+}
+
+class Permissions:
+    unrestricted = 0
+    standard = 1
+    member = 2
+    admin = 3

--- a/generic_message_handler.py
+++ b/generic_message_handler.py
@@ -1,4 +1,3 @@
-from dis import disco
 import re
 import inspect
 import discord

--- a/generic_message_handler.py
+++ b/generic_message_handler.py
@@ -4,7 +4,7 @@ import inspect
 
 class GenericMessageHandler:
     def __init__(self, commands, help_text, response,reply_private,permissionLevel): 
-        self.regex = [re.compile(f"^{command}*") for command in commands]
+        self.regex = [re.compile(f"^{command}") for command in commands]   
         self.response = response
         self.help_text = help_text
         self.private = reply_private
@@ -25,7 +25,7 @@ class GenericMessageHandler:
             handled = False
 
     async def unhandled(self,message):
-        self.reply(message, self.response)
+        await self.reply(message, "Unimplemented")
 
     async def reply(self, input, response):
         if self.private:
@@ -44,9 +44,9 @@ class GenericMessageHandler:
         self.handlers[regex] = handler
 
     async def method(self, message, permission):
-        if not self.match_regex(message.content):
-            return
         if permission < self.permissionRequired:
+            return
+        if not self.match_regex(message.content):
             return
 
         await self.reply(message,self.response)

--- a/generic_message_handler.py
+++ b/generic_message_handler.py
@@ -1,16 +1,52 @@
 import re
+from constants import Permissions
+import inspect
 
 class GenericMessageHandler:
-    def __init__(self, command, help_text, response, reply_private=False):
-        self.regex = re.compile(f"^{command}$")
+    def __init__(self, commands, help_text, response,reply_private,permissionLevel): 
+        self.regex = [re.compile(f"^{command}*") for command in commands]
         self.response = response
         self.help_text = help_text
         self.private = reply_private
+        self.permissionRequired = permissionLevel
+        self.handlers = {}
+        self.handler = None
+        self.setup_handlers()
 
-    async def method(self, message, permissions):
-        if not self.regex.match(message.content):
-            return
+    def setup_handlers(self):
+        handled = False
+        for regex in self.regex:
+            for member in inspect.getmembers(self, predicate=inspect.ismethod):
+                if regex.match(f"!{member[0]}"):
+                    self.handlers[regex] = member[1]
+                    handled = True
+            if not handled:
+                self.handlers[regex] = self.unhandled
+            handled = False
+
+    async def unhandled(self,message):
+        self.reply(message, self.response)
+
+    async def reply(self, input, response):
         if self.private:
-            await message.author.send(self.response)
+            await input.author.send(response)
         else:
-            await message.channel.send(self.response)
+            await input.channel.send(response)
+
+    def match_regex(self,content):
+        for regex in self.regex:
+            if regex.match(content):
+                self.handler = self.handlers[regex]
+                return True
+        return False
+
+    def set_regex_handler(self, regex, handler):
+        self.handlers[regex] = handler
+
+    async def method(self, message, permission):
+        if not self.match_regex(message.content):
+            return
+        if permission < self.permissionRequired:
+            return
+
+        await self.reply(message,self.response)

--- a/match_handler.py
+++ b/match_handler.py
@@ -1,10 +1,7 @@
-from email import message
 import inspect
 import re
 import datetime
-from sys import prefix
 import discord
-from urllib3 import Retry
 from generic_message_handler import GenericMessageHandler
 from constants import Permissions
 

--- a/match_handler.py
+++ b/match_handler.py
@@ -1,6 +1,10 @@
+from email import message
+import inspect
 import re
 import datetime
+from sys import prefix
 import discord
+from urllib3 import Retry
 from generic_message_handler import GenericMessageHandler
 from constants import Permissions
 
@@ -40,34 +44,29 @@ class Match():
         self.status = "inactive"
 
 class RegistrationHandler(GenericMessageHandler):
-    def __init__(self,commands,help_text,response,reply_private,permission=Permissions.admin):
-        super().__init__(commands,help_text,response,reply_private,permission)
+    def __init__(self,help_text,response,reply_private):
+        super().__init__(help_text,response,reply_private)
         self.registration_active = False
         self.match_next = None
         self.registration_next = None
         self.registration_post = None
         self.match_post = None
-        self.setup_handlers()
 
-    async def register(self,message):
-        self.match_post = await message.channel.send("React to this f m")
-        # await self.reply(message,"Registration not implemented")
+    def set_handler(self,handler):
+        self.handler = handler
+
+    async def message_register(self,message,permission):
+        if permission < Permissions.admin:
+            return
+        # self.match_post = await message.channel.send("React to this f m")
+        await self.reply(message,"Registration not implemented")
     
-    async def cancel(self, message):
+    async def message_cancel(self, message,permission):
+        if permission < Permissions.admin:
+            return
         await self.reply(message,"Cancelation not implements")
     
-    async def end(self, message):
+    async def message_end(self, message,permission):
+        if permission < Permissions.admin:
+            return
         await self.reply(message,"End not implemented")
-
-    async def method(self, message,permissions):
-        if isinstance(message,discord.Message):
-            if permissions < self.permissionRequired:
-                return
-            if not self.match_regex(message.content):
-                return
-            await self.handler(message)
-
-        elif isinstance(message, discord.RawReactionActionEvent):
-            if permissions < Permissions.member:
-                return
-            # await message.member.send("Thanks")

--- a/match_handler.py
+++ b/match_handler.py
@@ -1,5 +1,6 @@
 import re
 import datetime
+import discord
 from generic_message_handler import GenericMessageHandler
 from constants import Permissions
 
@@ -42,13 +43,15 @@ class RegistrationHandler(GenericMessageHandler):
     def __init__(self,commands,help_text,response,reply_private,permission=Permissions.admin):
         super().__init__(commands,help_text,response,reply_private,permission)
         self.registration_active = False
-        self.next_match = None
+        self.match_next = None
         self.registration_next = None
         self.registration_post = None
+        self.match_post = None
         self.setup_handlers()
 
     async def register(self,message):
-        await self.reply(message,"Registration not implemented")
+        self.match_post = await message.channel.send("React to this f m")
+        # await self.reply(message,"Registration not implemented")
     
     async def cancel(self, message):
         await self.reply(message,"Cancelation not implements")
@@ -57,9 +60,14 @@ class RegistrationHandler(GenericMessageHandler):
         await self.reply(message,"End not implemented")
 
     async def method(self, message,permissions):
-        if not self.match_regex(message.content):
-            return
-        if permissions < self.permissionRequired:
-            return
+        if isinstance(message,discord.Message):
+            if permissions < self.permissionRequired:
+                return
+            if not self.match_regex(message.content):
+                return
+            await self.handler(message)
 
-        await self.handler(message)
+        elif isinstance(message, discord.RawReactionActionEvent):
+            if permissions < Permissions.member:
+                return
+            # await message.member.send("Thanks")

--- a/match_handler.py
+++ b/match_handler.py
@@ -1,5 +1,8 @@
 import re
 import datetime
+from generic_message_handler import GenericMessageHandler
+from constants import Permissions
+
 
 class Match():
     def __init__(self,users,date=None) -> None:
@@ -35,14 +38,28 @@ class Match():
     def set_passive(self):
         self.status = "inactive"
 
-class RegistrationHandler:
-    def __init__(self):
+class RegistrationHandler(GenericMessageHandler):
+    def __init__(self,commands,help_text,response,reply_private,permission=Permissions.admin):
+        super().__init__(commands,help_text,response,reply_private,permission)
         self.registration_active = False
         self.next_match = None
         self.registration_next = None
         self.registration_post = None
-        self.my_regex = re.compile("^!registration")
+        self.setup_handlers()
 
-    def method(self, message):
-        if my_regex.match(message.content):
-            pass
+    async def register(self,message):
+        await self.reply(message,"Registration not implemented")
+    
+    async def cancel(self, message):
+        await self.reply(message,"Cancelation not implements")
+    
+    async def end(self, message):
+        await self.reply(message,"End not implemented")
+
+    async def method(self, message,permissions):
+        if not self.match_regex(message.content):
+            return
+        if permissions < self.permissionRequired:
+            return
+
+        await self.handler(message)


### PR DESCRIPTION
Added configuration scheme using JSON-structured files. The user can configure the bot by writing out a file
'config' or on starting the bot, supply the information through the terminal.

In order to handle registration/deregistration, match objects have to either be shared between multiple handlers,
or one handler has to be able to handle multiple commands.
Propose solution where a Generic dispatch function searches through each Handler's methods and try to match incoming commands with an object's own methods. This require a naming scheme and I propose we do it like:
*Methods handling commands coming as messages have prefix:*
message_<command_name> ie:
```
registrationHandler method for command !register:
async def message_register(args*...):
    // code ...
```
* Methods for handling reaction to posts:*
reaction_<reaction_event_type> ie:
```
registrationHandler method for added reactions to post
async def reaction_add():
    // code...
```
Privilege check now done by user's discord channel permissions. If the user has 'permission to manage roles(manage_roles)'
the user is a bot admin. This removes the need for configuration and maintaining a list of admin IDs.

Members of the channel can be players(registrate for matches) without admin rights by configuring the ID of the member role in the config file, or typed through the commandline when starting the bot.

Just an idea! hope to hear some feedback